### PR TITLE
Add disable compression command line option

### DIFF
--- a/examples/torch/classification/README.md
+++ b/examples/torch/classification/README.md
@@ -31,6 +31,22 @@ To prepare the ImageNet dataset, refer to the following [tutorial](https://githu
 
 - If you did not install the package, add the repository root folder to the `PYTHONPATH` environment variable.
 - Go to the `examples/torch/classification` folder.
+
+#### Test Pretrained Model
+
+Before compressing a model, it is highly recommended checking the accuracy of the pretrained model. All models which are supported in the sample has pretrained weights for ImageNet. 
+
+To load pretrained weights into a model and then evaluate the accuracy of that model, make sure that the pretrained=True option is set in the configuration file and use the following command:
+```bash
+python main.py \
+--mode=test \
+--config=configs/quantization/mobilenet_v2_imagenet_int8.json \
+--data=<path_to_imagenet_dataset> \
+--disable-compression 
+```
+
+#### Compress Pretrained Model
+
 - Run the following command to start compression with fine-tuning on GPUs:
     ```
     python main.py -m train --config configs/quantization/mobilenet_v2_imagenet_int8.json --data /data/imagenet/ --log-dir=../../results/quantization/mobilenet_v2_int8/
@@ -43,11 +59,10 @@ To prepare the ImageNet dataset, refer to the following [tutorial](https://githu
 
 #### Validate Your Model Checkpoint
 
-To estimate the test scores of your model checkpoint, use the following command:
+To estimate the test scores of your trained model checkpoint, use the following command:
 ```
 python main.py -m test --config=configs/quantization/mobilenet_v2_imagenet_int8.json --resume <path_to_trained_model_checkpoint>
 ```
-To validate an FP32 model checkpoint, make sure the compression algorithm settings are empty in the configuration file or `pretrained=True` is set.
 
 **WARNING**: The samples use `torch.load` functionality for checkpoint loading which, in turn, uses pickle facilities by default which are known to be vulnerable to arbitrary code execution attacks. **Only load the data you trust**
 

--- a/examples/torch/common/argparser.py
+++ b/examples/torch/common/argparser.py
@@ -1,5 +1,5 @@
 """
- Copyright (c) 2019 Intel Corporation
+ Copyright (c) 2022 Intel Corporation
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -172,7 +172,13 @@ def get_common_argument_parser():
     parser.add_argument('-p', '--print-freq', default=10, type=int,
                         metavar='N', help='Print frequency (batch iterations). '
                                           'Default: 10)')
-
+    
+    parser.add_argument(
+        "--disable-compression",
+        help="Disable compression",
+        action="store_true",
+    )
+    
     return parser
 
 

--- a/examples/torch/common/sample_config.py
+++ b/examples/torch/common/sample_config.py
@@ -1,5 +1,5 @@
 """
- Copyright (c) 2020 Intel Corporation
+ Copyright (c) 2022 Intel Corporation
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -115,7 +115,9 @@ def create_sample_config(args, parser) -> SampleConfig:
     if sample_config.get("target_device") is not None:
         target_device = sample_config.pop("target_device")
         loaded_json["target_device"] = target_device
-
+    
     nncf_config = NNCFConfig.from_dict(loaded_json)
+    if args.disable_compression and 'compression' in nncf_config:
+        del nncf_config['compression']
     sample_config.nncf_config = nncf_config
     return sample_config

--- a/examples/torch/object_detection/README.md
+++ b/examples/torch/object_detection/README.md
@@ -11,12 +11,6 @@ This sample demonstrates DL model compression capabailites for object detection 
 
 ## Installation
 
-At this point it is assumed that you have already installed nncf
-
-```
-pip install nncf
-```
-
 To work with the sample you should install the corresponding Python package dependencies
 
 ```
@@ -32,6 +26,15 @@ This scenario demonstrates quantization with fine-tuning of SSD300 on VOC datase
 #### Run object detection sample
 - If you did not install the package then add the repository root folder to the `PYTHONPATH` environment variable
 - Navigate to the `examples/torch/object_detection` folder
+- (Optional) Before compressing a model, it is highly recommended checking the accuracy of the pretrained model, use the following command: 
+  ```bash
+  python main.py \
+  --mode=test \
+  --config=configs/quantization/retinanet_coco_int8.json \
+  --weights=<path_to_H5_file_with_pretrained_weights>
+  --data=<path_to_dataset> \
+  --disable-compression 
+  ```
 - Run the following command to start compression with fine-tuning on GPUs:
 `python main.py -m train --config configs/ssd300_vgg_voc_int8.json --data <path_to_dataset> --log-dir=../../results/quantization/ssd300_int8`
 It may take a few epochs to get the baseline accuracy results.
@@ -42,7 +45,7 @@ It may take a few epochs to get the baseline accuracy results.
 om scratch.
 
 #### Validate your model checkpoint
-To estimate the test scores of your model checkpoint use the following command:
+To estimate the test scores of your trained model checkpoint use the following command:
 `python main.py -m test --config=configs/ssd300_vgg_voc_int8.json --data <path_to_dataset> --resume <path_to_trained_model_checkpoint>`
 If you want to validate an FP32 model checkpoint, make sure the compression algorithm settings are empty in the configuration file or `pretrained=True` is set.
 
@@ -50,7 +53,7 @@ If you want to validate an FP32 model checkpoint, make sure the compression algo
 
 #### Export compressed model
 To export trained model to ONNX format use the following command:
-`python main.py -m test --config configs/ssd300_vgg_voc_int8.json --data <path_to_dataset> --resume <path_to_compressed_model_checkpoint> --to-onnx=../../results/ssd300_int8.onnx`
+`python main.py -m export --config configs/ssd300_vgg_voc_int8.json --data <path_to_dataset> --resume <path_to_compressed_model_checkpoint> --to-onnx=../../results/ssd300_int8.onnx`
 
 #### Export to OpenVINO Intermediate Representation (IR)
 

--- a/examples/torch/semantic_segmentation/README.md
+++ b/examples/torch/semantic_segmentation/README.md
@@ -26,6 +26,16 @@ This scenario demonstrates quantization with fine-tuning of UNet on Mapillary Vi
 #### Run semantic segmentation sample
 - If you did not install the package then add the repository root folder to the `PYTHONPATH` environment variable
 - Navigate to the `examples/torch/segmentation` folder
+- (Optional) Before compressing a model, it is highly recommended checking the accuracy of the pretrained model, use the following command:
+  ```bash
+  python main.py \
+  --mode=test \
+  --config=configs/quantization/mask_rcnn_coco_int8.json \
+  --weights=<path_to_ckpt_file_with_pretrained_weights> \
+  --data=<path_to_dataset> \
+  --batch-size=1 \
+  --disable-compression
+  ```
 - Run the following command to start compression with fine-tuning on GPUs:
 `python main.py -m train --config configs/unet_mapillary_int8.json --data <path_to_dataset> --weights <path_to_fp32_model_checkpoint>`
 
@@ -39,7 +49,7 @@ om scratch.
 
 
 #### Validate your model checkpoint
-To estimate the test scores of your model checkpoint use the following command:
+To estimate the test scores of your trained model checkpoint use the following command:
 `python main.py -m test --config=configs/unet_mapillary_int8.json --resume <path_to_trained_model_checkpoint>`
 If you want to validate an FP32 model checkpoint, make sure the compression algorithm settings are empty in the configuration file or `pretrained=True` is set.
 


### PR DESCRIPTION
### Changes

Simplify scenario of evaluation pre-trained model.  I suggest using the `disable-compression` option instead of removing the compression section from the config file.

### Reason for changes

Customer request

### Related tickets

N/A

### Tests

N/A
